### PR TITLE
correct initialization for msgrpc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Original project  : https://github.com/allfro/pymetasploit
 ## Starting Metasploit RPC server
 
 ### Msfconsole
-This will start the RPC server on port 55553 as well as the Metasploit console UI
+This will start the RPC server on port 55552 as well as the Metasploit console UI
 ```bash
 $ msfconsole
-msf> load msgrpc [-P yourpassword]
+msf> load msgrpc [Pass=yourpassword] 
 ```
 ### msfrpcd
-This will start the RPC server on port 55552 and will just start the RPC server in the background
+This will start the RPC server on port 55553 and will just start the RPC server in the background
 ```bash
 $ msfrpcd -P yourpassword
 ```

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email='danhmcinerney@gmail.com',
     description='A full-fledged msfrpc library for Metasploit framework.',
     license='GPL',
-    packages=find_packages('pymetasploit3'),
+    packages=find_packages(),
     scripts=[
         'pymetasploit3/scripts/pymsfconsole.py',
         'pymetasploit3/scripts/pymsfrpc.py'


### PR DESCRIPTION
I still had issues with setup.py. After installing with 'python3 setup.py install', I got module not found errors with import statements like 'from pymetasploit3.msfrpc import *', with msfrpc not being found. Corrected it by not passing a directory to find_packages(). 
In readme, corrected the initialization for msgrpc pass='password', using this reference: https://blog.ehcgroup.io/wp-content/uploads/2017/08/metasploit-rpc-api-guide-1.pdf, but I'm not sure it's a good reference for other things being almost two years old. Also, in readme, msgrpc defaults to 55552, and msfrpcd 55553. 