### PR TITLE
fix blocking method call when waiting for exploit output

### DIFF
--- a/pymetasploit3/msfrpc.py
+++ b/pymetasploit3/msfrpc.py
@@ -2069,7 +2069,8 @@ class MsfConsole(object):
         if mod.moduletype == 'exploit':
             if payload:
                 options_str += 'set payload {}\n'.format(payload)
-        options_str += 'run'
+        # Run the module without directly opening a command line
+        options_str += 'run -z'
         self.rpc.consoles.console(self.cid).write(options_str)
         # Sometimes it takes a while for the console to write all the options
         # While it's writing the options the console will not be busy


### PR DESCRIPTION
Fixes the problem described in this issue: https://github.com/DanMcInerney/pymetasploit3/issues/9

run_module_with_output now returns the console output even if a session spawns, because the '-z' flag keeps metasploit from opening a command line.