### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ $ msfrpcd -P yourpassword -S
 
 ```python
 >>> from pymetasploit3.msfrpc import MsfRpcClient
->>> client = MsfRpcClient('yourpassword')
+>>> client = MsfRpcClient('yourpassword', ssl=True)
 ```
 ### Connecting to `msfconsole` with `msgrpc` plugin loaded
 
 ```python
 >>> from pymetasploit3.msfrpc import MsfRpcClient
->>> client = MsfRpcClient('yourpassword', port=55552)
+>>> client = MsfRpcClient('yourpassword', port=55552, True)
 ```
 
 ### MsfRpcClient


### PR DESCRIPTION
Add `ssl=True` to the examples, as by default msfrpcd is SSL by default. This should help with #5.