### PR TITLE
Fixed setting target value when running a module using the console

### DIFF
--- a/pymetasploit3/msfrpc.py
+++ b/pymetasploit3/msfrpc.py
@@ -2218,6 +2218,8 @@ class MsfConsole(object):
         # Set payload params
         if mod.moduletype == 'exploit':
             opts['TARGET'] = mod.target
+            options_str += 'set TARGET {}\n'.format(mod.target)
+
             if 'DisablePayloadHandler' in opts and opts['DisablePayloadHandler']:
                 pass
             elif isinstance(payload, PayloadModule):


### PR DESCRIPTION
When running a module using a `console`, the `run_module_with_output` method does not add a `set TARGET <ID>` line to the `outputs_str` variable. This prevents some exploits from running successfully when the target value is changed. 