### PR TITLE
fix default port in help text

### DIFF
--- a/pymetasploit3/utils.py
+++ b/pymetasploit3/utils.py
@@ -17,7 +17,7 @@ def parseargs():
     p.add_option("-S", dest="ssl", help="Disable SSL on the RPC socket", action="store_false", default=True)
     p.add_option("-U", dest="username", help="Specify the username to access msfrpcd", metavar="opt", default="msf")
     p.add_option("-a", dest="server", help="Connect to this IP address", metavar="host", default="127.0.0.1")
-    p.add_option("-p", dest="port", help="Connect to the specified port instead of 55552", metavar="opt", default=55553)
+    p.add_option("-p", dest="port", help="Connect to the specified port instead of 55553", metavar="opt", default=55553)
     o, a = p.parse_args()
     if o.password is None:
         print('[-] Error: a password must be specified (-P)\n')


### PR DESCRIPTION
Help text should indicate port 55553 not 55552