### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ msf> load msgrpc [Pass=yourpassword]
 ### msfrpcd
 This will start the RPC server on port 55553 and will just start the RPC server in the background
 ```bash
-$ msfrpcd -P yourpassword -S
+$ msfrpcd -P yourpassword 
 ```
 
 ## RPC client


### PR DESCRIPTION
You give the -S flag which lets the server start without an ssl, yet set ssl=True in the connecting snippet.