### PR TITLE
added timeout to run_module_with_output

### DIFF
--- a/pymetasploit3/msfrpc.py
+++ b/pymetasploit3/msfrpc.py
@@ -2210,7 +2210,7 @@ class MsfConsole(object):
             if c['id'] == self.cid:
                 return c['busy']
 
-    def run_module_with_output(self, mod, payload=None, run_as_job=False):
+    def run_module_with_output(self, mod, payload=None, run_as_job=False, timeout=301):
         """
         Execute a module and wait for the returned data
 
@@ -2257,9 +2257,13 @@ class MsfConsole(object):
             options_str += " -j"
         self.rpc.consoles.console(self.cid).write(options_str)
         data = ''
+        timer = 0
         while data == '' or self.rpc.consoles.console(self.cid).is_busy():
             time.sleep(1)
             data += self.rpc.consoles.console(self.cid).read()['data']
+            timer += 1
+            if timer > timeout:
+                break
         return data
 
 


### PR DESCRIPTION
During my testing, for whatever reason, I've found that running modules in a console (especially exploits) isn't guaranteed to actually run. This isn't an issue in pymetasploit3, this is an issue with Metasploit. Because of this, the current implementation of "continue getting data _forever_ while the console isn't busy and we haven't seen any data yet" doesn't work very well for me.

I've found that the easiest solution at the moment is adding a timeout to this function. I've defaulted it to 5 minutes, but of course this can be changed.

Let me know if you've seen the same thing and I'm missing something obvious!

 