### PR TITLE
Fix PyPI setup.py formatting and added GitHub Actions PyPI publishing

### DIFF
--- a/.github/workflows/buildandreleasepypi.yml
+++ b/.github/workflows/buildandreleasepypi.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/pymetasploit3 #testcomment
+      url: https://pypi.org/p/pymetasploit3
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:

--- a/.github/workflows/buildandreleasepypi.yml
+++ b/.github/workflows/buildandreleasepypi.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: master
-    - name: Increment version number
+    - name: Replace run number and attempt in setup.py
       uses: jacobtomlinson/gha-find-replace@v3
       with:
         find: "GITHUB_RUN_NUMBER.GITHUB_RUN_ATTEMPT"

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Increment version number
       uses: jacobtomlinson/gha-find-replace@v3
       with:
-        find: "VERSION_NUMBER"
+        find: "VERSION_MINOR_RELEASE"
         replace: ${{ github.run_attempt }}
         regex: false
         include: "setup.py"

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -19,12 +19,12 @@ jobs:
       with:
         ref: master
     - name: Increment version number
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "VERSION_NUMBER"
-          replace: ${{ github.run_attempt }}
-          regex: false
-          include: "**setup.py"
+      uses: jacobtomlinson/gha-find-replace@v3
+      with:
+        find: "VERSION_NUMBER"
+        replace: ${{ github.run_attempt }}
+        regex: false
+        include: "**setup.py"
     - name: Build distribution
       run: python3 setup.py sdist
     - name: Publish package distributions to PyPI

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,0 +1,20 @@
+name: GitHub Actions Demo
+run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+on:
+  push:
+    branches:
+      - master
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pymetasploit3
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - name: Build distribution
+      run: python3 .\setup.py sdist
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -24,7 +24,7 @@ jobs:
         find: "VERSION_NUMBER"
         replace: ${{ github.run_attempt }}
         regex: false
-        include: "./setup.py"
+        include: "setup.py"
     - name: Build distribution
       run: python3 setup.py sdist
     - name: Publish package distributions to PyPI

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -25,6 +25,9 @@ jobs:
         replace: ${{ github.run_attempt }}
         regex: false
         include: "setup.py"
+    - name: Debug setup.py
+      run:
+        run: cat setup.py
     - name: Build distribution
       run: python3 setup.py sdist
     - name: Publish package distributions to PyPI

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -15,6 +15,6 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
     - name: Build distribution
-      run: python3 .\setup.py sdist
+      run: python3 setup.py sdist
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -26,8 +26,7 @@ jobs:
         regex: false
         include: "setup.py"
     - name: Debug setup.py
-      run:
-        run: cat setup.py
+      run: cat setup.py
     - name: Build distribution
       run: python3 setup.py sdist
     - name: Publish package distributions to PyPI

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -14,6 +14,10 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
+    - name: Checkout files
+      uses: actions/checkout@v4
+      with:
+        ref: master
     - name: Build distribution
       run: python3 setup.py sdist
     - name: Publish package distributions to PyPI

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -24,7 +24,7 @@ jobs:
         find: "VERSION_NUMBER"
         replace: ${{ github.run_attempt }}
         regex: false
-        include: "**setup.py"
+        include: "setup.py"
     - name: Build distribution
       run: python3 setup.py sdist
     - name: Publish package distributions to PyPI

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/pymetasploit3
+      url: https://pypi.org/p/pymetasploit3 #testcomment
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Increment version number
       uses: jacobtomlinson/gha-find-replace@v3
       with:
-        find: "VERSION_MINOR_RELEASE"
-        replace: ${{ github.run_attempt }}
+        find: "GITHUB_RUN_NUMBER.GITHUB_RUN_ATTEMPT"
+        replace: ${{ github.run_number }}.${{ github.run_attempt }}
         regex: false
         include: "setup.py"
     - name: Debug setup.py

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -24,7 +24,7 @@ jobs:
         find: "VERSION_NUMBER"
         replace: ${{ github.run_attempt }}
         regex: false
-        include: "setup.py"
+        include: "./setup.py"
     - name: Build distribution
       run: python3 setup.py sdist
     - name: Publish package distributions to PyPI

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,5 +1,5 @@
-name: GitHub Actions Demo
-run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+name: Build and upload to PyPI
+run-name: Building and releasing to PyPI
 on:
   push:
     branches:
@@ -18,6 +18,13 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: master
+    - name: Increment version number
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "VERSION_NUMBER"
+          replace: ${{ github.run_attempt }}
+          regex: false
+          include: "**setup.py"
     - name: Build distribution
       run: python3 setup.py sdist
     - name: Publish package distributions to PyPI

--- a/Pipfile
+++ b/Pipfile
@@ -13,3 +13,7 @@ twine = "*"
 
 [requires]
 python_version = "3.7"
+
+[pypi]
+username = __token__
+password = pypi-AgEIcHlwaS5vcmcCJGNiMDY5NmE1LTJhNWItNDY2YS1iN2JhLWNiZWRjNDA2MGJlMAACKlszLCI5ODcyNWUwMi00NzAwLTQ0YmEtYmM3Yi0wY2FlMDViNjBhYjMiXQAABiAwxOxzbZi-edIXq7RvHQ1y418jR1QSAi_acihYMltbKQ

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,3 @@ twine = "*"
 
 [requires]
 python_version = "3.7"
-
-[pypi]
-username = __token__
-password = pypi-AgEIcHlwaS5vcmcCJGNiMDY5NmE1LTJhNWItNDY2YS1iN2JhLWNiZWRjNDA2MGJlMAACKlszLCI5ODcyNWUwMi00NzAwLTQ0YmEtYmM3Yi0wY2FlMDViNjBhYjMiXQAABiAwxOxzbZi-edIXq7RvHQ1y418jR1QSAi_acihYMltbKQ

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Pymetasploit3
-=======
+=============
 
 Pymetasploit3 is a full-fledged Python3 Metasploit automation library. It can interact with Metasploit either through msfrpcd or the msgrpc plugin in msfconsole.
 

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ def read(fname):
 
 
 setup(
-    name='pymetasploit3',
+    name='testpymetasploit3',
     author='Dan McInerney',
-    version='1.0',
+    version='1.3',
     author_email='danhmcinerney@gmail.com',
     description='A full-fledged msfrpc library for Metasploit framework.',
     license='GPL',
@@ -25,7 +25,8 @@ setup(
         'requests',
         'retry'
     ],
-    url='https://github.com/DanMcInerney/pymetasploit3',
+    url='https://github.com/DanMcInerney/testpymetasploit3',
     download_url='https://github.com/DanMcInerney/pymetasploit3/zipball/master',
-    long_description=read('README.md')
+    long_description=read('README.md'),
+    long_description_content_type="text/markdown"
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 setup(
     name='testpymetasploit3',
     author='Dan McInerney',
-    version='1.3',
+    version='VERSION_NUMBER',
     author_email='danhmcinerney@gmail.com',
     description='A full-fledged msfrpc library for Metasploit framework.',
     license='GPL',

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ def read(fname):
 
 
 setup(
-    name='testpymetasploit3',
+    name='pymetasploit3',
     author='Dan McInerney',
-    version='1.5.GITHUB_RUN_NUMBER.GITHUB_RUN_ATTEMPT',
+    version='1.0.GITHUB_RUN_NUMBER.GITHUB_RUN_ATTEMPT',
     author_email='danhmcinerney@gmail.com',
     description='A full-fledged msfrpc library for Metasploit framework.',
     license='GPL',
@@ -25,7 +25,7 @@ setup(
         'requests',
         'retry'
     ],
-    url='https://github.com/DanMcInerney/testpymetasploit3',
+    url='https://github.com/DanMcInerney/pymetasploit3',
     download_url='https://github.com/DanMcInerney/pymetasploit3/zipball/master',
     long_description=read('README.md'),
     long_description_content_type="text/markdown"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 setup(
     name='testpymetasploit3',
     author='Dan McInerney',
-    version='1.4VERSION_MINOR_RELEASE',
+    version='1.5.GITHUB_RUN_NUMBER.GITHUB_RUN_ATTEMPT',
     author_email='danhmcinerney@gmail.com',
     description='A full-fledged msfrpc library for Metasploit framework.',
     license='GPL',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 setup(
     name='testpymetasploit3',
     author='Dan McInerney',
-    version='VERSION_NUMBER',
+    version='1.4VERSION_MINOR_RELEASE',
     author_email='danhmcinerney@gmail.com',
     description='A full-fledged msfrpc library for Metasploit framework.',
     license='GPL',


### PR DESCRIPTION
I fixed some formatting issues that were preventing the library from being uploaded to PyPI, specifically the title line and the specification for markdown content type.

I also added automatic publishing to PyPI using GitHub actions. To enable this, the owner of the PyPI project (Dan) should just add the repo as a trusted published on PyPI (instructions https://docs.pypi.org/trusted-publishers/adding-a-publisher/). After that, I would suggest squashing and merging this pull request so that the GitHub action immediately applies and runs.

This means that every commit will automatically be pushed to PyPI.